### PR TITLE
Fix Percent numbers for pacing sliders

### DIFF
--- a/src/settings/components/PaceSettings.tsx
+++ b/src/settings/components/PaceSettings.tsx
@@ -70,7 +70,7 @@ export const PaceSettings = () => {
         value={steepness}
         onChange={setSteepness}
       />
-      <Measure value={steepness * 100} chars={2} unit='%' />
+      <Measure value={Math.floor(steepness * 100)} chars={3} unit='%' />
       <SettingsLabel htmlFor='timeshift'>Timeshift</SettingsLabel>
       <Slider
         id='timeshift'
@@ -80,7 +80,7 @@ export const PaceSettings = () => {
         value={timeshift}
         onChange={setTimeshift}
       />
-      <Measure value={timeshift * 100} chars={2} unit='%' />
+      <Measure value={Math.floor(timeshift * 100)} chars={3} unit='%' />
       <Space size='medium' />
       <SettingsLabel style={{ alignSelf: 'flex-end' }}>start</SettingsLabel>
       <div


### PR DESCRIPTION
Fix makes it so 100% shows as 100% and not 10%, while also truncating the number to the nearest integer, as the computer doesn't represent certain floats very well (55% shows as 55.% when characters are increased to 3, due to it not being a repeating number in binary)