### PR TITLE
Updated yarn build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ To locally run it:
 git clone https://github.com/clynamic/joi.how.git
 cd joi.how
 yarn
-yarn start
+yarn build
+yarn preview
 ```
-
+4. open one of the URLs listed in your browser
 ### Social
 
 - We have an [e6 forum thread](https://e621.net/forum_topics/23796). We'd love to hear your feedback.


### PR DESCRIPTION
'yarn start' returns an error because there is no such command(script?) in the package.json. Added commands that DO exist in the package json, namely 'build' and 'preview' and a line explaining what to do next.